### PR TITLE
i18n improvements

### DIFF
--- a/cf7-telegram/cf7-telegram.php
+++ b/cf7-telegram/cf7-telegram.php
@@ -15,7 +15,6 @@ use iTRON\cf7Telegram\Settings;
 
 define( 'WPCF7TG_PLUGIN_NAME', plugin_basename( __FILE__ ) );
 
-define( 'WPCF7TG_DOMAIN', 'cf7-telegram' );
 define( 'WPCF7TG_VERSION', '1.0-RC1' );
 define( 'WPCF7TG_FILE', __FILE__ );
 
@@ -26,8 +25,6 @@ require __DIR__ . '/vendor/autoload.php';
 
 add_action( 'setup_theme', [ Client::getInstance(), 'init' ] );
 Settings::init();
-
-load_plugin_textdomain( WPCF7TG_DOMAIN, FALSE,  dirname( WPCF7TG_PLUGIN_NAME ) . '/languages' );
 
 add_action( 'in_plugin_update_message-' . WPCF7TG_PLUGIN_NAME, 'wpcf7tg_plugin_update_message', 10, 2 );
 

--- a/cf7-telegram/classes/wpcf7telegram.php
+++ b/cf7-telegram/classes/wpcf7telegram.php
@@ -37,17 +37,18 @@ class wpcf7_Telegram{
 	);
 	
 	function __construct(){
-		if ( ! empty( self::$instance ) ) return new WP_Error( 'duplicate_object', __( 'Prevent duplicate object creation', WPCF7TG_DOMAIN ) );
+		if ( ! empty( self::$instance ) ) return new WP_Error( 'duplicate_object', __( 'Prevent duplicate object creation', 'cf7-telegram' ) );
 	}
 	
 	private function init(){
 		$this->addons = array(
-			'wpcf7tg_mediafiles' => __( 'File Sending', WPCF7TG_DOMAIN ),
+			'wpcf7tg_mediafiles' => __( 'File Sending', 'cf7-telegram' ),
 		);
 		
 		$this->load_bot_token();
 		$this->load_chats();
 		
+		add_action( 'plugins_loaded', array( $this, 'translations' ) );
 		add_action( 'admin_menu', array( $this, 'menu_page' ) );
 		add_action( 'admin_init', array( $this, 'save_form' ), 50 );
 		add_action( 'admin_init', array( $this, 'settings_section' ), 999 );
@@ -66,6 +67,10 @@ class wpcf7_Telegram{
 		endif;
 
 		return self::$instance;
+	}
+
+	public function translations() {
+		load_plugin_textdomain( 'cf7-telegram', FALSE,  dirname( WPCF7TG_PLUGIN_NAME ) . '/languages' );
 	}
 	
 	public function current_screen(){
@@ -88,11 +93,11 @@ class wpcf7_Telegram{
 			'ajax'		=> admin_url('admin-ajax.php'),
 			'nonce'		=> wp_create_nonce( 'wpcf7_telegram_nonce' ),
 			'l10n'		=> array(
-				'confirm_approve'	=> __( 'Do you really want to approve?', WPCF7TG_DOMAIN ),
-				'confirm_refuse'	=> __( 'Do you really want to refuse?', WPCF7TG_DOMAIN ),
-				'confirm_pause'		=> __( 'Do you really want to pause?', WPCF7TG_DOMAIN ),
-				'approved'	=> __( 'Successfully approved', WPCF7TG_DOMAIN ),
-				'refused'	=> __( 'Request refused', WPCF7TG_DOMAIN ),
+				'confirm_approve'	=> __( 'Do you really want to approve?', 'cf7-telegram' ),
+				'confirm_refuse'	=> __( 'Do you really want to refuse?', 'cf7-telegram' ),
+				'confirm_pause'		=> __( 'Do you really want to pause?', 'cf7-telegram' ),
+				'approved'	=> __( 'Successfully approved', 'cf7-telegram' ),
+				'refused'	=> __( 'Request refused', 'cf7-telegram' ),
 			),
 		) );
 	}
@@ -101,14 +106,14 @@ class wpcf7_Telegram{
 		$me = self::get_instance();
 		add_settings_section(
 			'wpcf7_tg_sections__main', 
-			__( 'Bot-settings', WPCF7TG_DOMAIN ),
+			__( 'Bot-settings', 'cf7-telegram' ),
 			array( $me, 'sections__main_callback_function' ),
 			'wpcf7tg_settings_page'
 		);
 		
 		add_settings_field( 
 			'bot_token', 
-			__( 'Bot Token<br/><small>You need to create your own Telegram-Bot.<br/><a target="_blanc" href="https://core.telegram.org/bots#3-how-do-i-create-a-bot">How to create</a></small>', WPCF7TG_DOMAIN ), 
+			__( 'Bot Token<br/><small>You need to create your own Telegram-Bot.<br/><a target="_blanc" href="https://core.telegram.org/bots#3-how-do-i-create-a-bot">How to create</a></small>', 'cf7-telegram' ), 
 			array( $me, 'settings_clb' ), 
 			'wpcf7tg_settings_page', 
 			'wpcf7_tg_sections__main', 
@@ -117,7 +122,7 @@ class wpcf7_Telegram{
 				'name'		=> 'wpcf7_telegram_tkn',
 				'value'		=> self::has_token_constant() ? '' : $me->get_bot_token(),
 				'disabled'	=> self::has_token_constant(),
-				'ph'		=> self::has_token_constant() ? __( 'Defined by WPFC7TG_BOT_TOKEN constant', WPCF7TG_DOMAIN ) : __( 'or define by WPFC7TG_BOT_TOKEN constant', WPCF7TG_DOMAIN ),
+				'ph'		=> self::has_token_constant() ? __( 'Defined by WPFC7TG_BOT_TOKEN constant', 'cf7-telegram' ) : __( 'or define by WPFC7TG_BOT_TOKEN constant', 'cf7-telegram' ),
 			)
 		);
 	}
@@ -145,7 +150,7 @@ class wpcf7_Telegram{
 	function plugin_menu_cbf(){
 	?>	
 		<div class="wrap">	
-			<h1><?php echo __( 'Telegram notificator settings', WPCF7TG_DOMAIN ); ?></h1>
+			<h1><?php echo __( 'Telegram notificator settings', 'cf7-telegram' ); ?></h1>
 			<?php 
 				$this->bot_status();
 				$this->view_full_list();
@@ -155,7 +160,7 @@ class wpcf7_Telegram{
 				<?php settings_fields( 'wpcf7tg_settings_page' ); ?>	
 				<?php do_settings_sections( 'wpcf7tg_settings_page' ); ?> 
 				<input type="hidden" name="wpcf7tg_settings_form_action" value="save" />
-				<p><?php echo __( 'Just use the shortcode <code>[telegram]</code> in the form for activate notification through Telegram.', WPCF7TG_DOMAIN ); ?></p>
+				<p><?php echo __( 'Just use the shortcode <code>[telegram]</code> in the form for activate notification through Telegram.', 'cf7-telegram' ); ?></p>
 				<?php submit_button(); ?>	
 			</form>	
 			<?php
@@ -299,7 +304,7 @@ class wpcf7_Telegram{
 		$check = $this->api_request( 'getMe' );
 		
 		if ( false === $check ) 
-		return new WP_Error( 'check_bot_error', __( 'An error has occured. See php error log.', WPCF7TG_DOMAIN ) );
+		return new WP_Error( 'check_bot_error', __( 'An error has occured. See php error log.', 'cf7-telegram' ) );
 
 		return $check;		
 	}
@@ -310,28 +315,29 @@ class wpcf7_Telegram{
 		$status_format = 
 			'<div class="check_bot %s">
 				<strong class="status">%s</strong>
-				<div>'. __( 'Bot username', WPCF7TG_DOMAIN ) . ': <code class="bot_username">%s</code></div>
+				<div>'. __( 'Bot username', 'cf7-telegram' ) . ': <code class="bot_username">%s</code></div>
 			</div>';
 		
 		if ( ! is_wp_error( $check_bot ) ) :
 			echo ( true === @ $check_bot->ok ) ? 
-				sprintf( $status_format, 'online', __( 'Bot is online', WPCF7TG_DOMAIN ), '@' . $check_bot->result->username ) :
-				sprintf( $status_format, 'failed', __( 'Bot is broken', WPCF7TG_DOMAIN ), __( 'unknown', WPCF7TG_DOMAIN ) );
+				sprintf( $status_format, 'online', __( 'Bot is online', 'cf7-telegram' ), '@' . $check_bot->result->username ) :
+				sprintf( $status_format, 'failed', __( 'Bot is broken', 'cf7-telegram' ), __( 'unknown', 'cf7-telegram' ) );
 		else :
 			echo $check_bot->get_error_message();
 		endif;
 	}
 	
 	private function view_full_list(){
-		echo '<h2>'. __( 'Subscribers list', WPCF7TG_DOMAIN ) .'</h2>';
+		echo '<h2>'. __( 'Subscribers list', 'cf7-telegram' ) .'</h2>';
 		
 		$req = $this->pending_html_list();
 		$app = $this->approved_html_list();
 		
-		if ( ! $req && ! $app ) _e( 'List is empty', WPCF7TG_DOMAIN );
-		
-		echo '<p>', sprintf( __( 'Add user: send the <code>%s</code> comand to your bot', WPCF7TG_DOMAIN ), '/'. $this->cmd ), '</p>';
-		echo '<p>', sprintf( __( 'Add group: add your bot to the group and send the <code>%s</code> comand to your group', WPCF7TG_DOMAIN ), '/'. $this->cmd ), '</p>';
+		if ( ! $req && ! $app ) _e( 'List is empty', 'cf7-telegram' );
+		/* translators: "cf7tg_start" command */
+		echo '<p>', sprintf( __( 'Add user: send the <code>%s</code> comand to your bot', 'cf7-telegram' ), '/'. $this->cmd ), '</p>';
+		/* translators: "cf7tg_start" command */
+		echo '<p>', sprintf( __( 'Add group: add your bot to the group and send the <code>%s</code> comand to your group', 'cf7-telegram' ), '/'. $this->cmd ), '</p>';
 	}
 	
 	private function get_listitem_data( $chat, $status = 'pending' ){
@@ -425,7 +431,7 @@ class wpcf7_Telegram{
 		
 		$this->api_request( 'sendMessage', array(
 			'chat_id'					=> $chat_id,
-			'text'						=> __( 'Subscribed for Contact Form 7 notifications from', WPCF7TG_DOMAIN ) . ' ' . home_url(),
+			'text'						=> __( 'Subscribed for Contact Form 7 notifications from', 'cf7-telegram' ) . ' ' . home_url(),
 			'disable_web_page_preview'	=> true,
 		) );
 		
@@ -522,9 +528,9 @@ class wpcf7_Telegram{
 				%6$s
 			</div>
 			<div class="buttons">
-				<a class="approve" data-action="approve" ><span class="screen-reader-text">'. __( 'Approve', WPCF7TG_DOMAIN ) . '</span>'. __( 'Approve', WPCF7TG_DOMAIN ) . '</a>
-				<a class="pause" data-action="pause" ><span class="screen-reader-text">'. __( 'Pause', WPCF7TG_DOMAIN ) . '</span>'. __( 'Pause', WPCF7TG_DOMAIN ) . '</a>
-				<a class="refuse" data-action="refuse" ><span class="screen-reader-text">'. __( 'Delete', WPCF7TG_DOMAIN ) . '</span>'. __( 'Delete', WPCF7TG_DOMAIN ) . '</a>
+				<a class="approve" data-action="approve" ><span class="screen-reader-text">'. __( 'Approve', 'cf7-telegram' ) . '</span>'. __( 'Approve', 'cf7-telegram' ) . '</a>
+				<a class="pause" data-action="pause" ><span class="screen-reader-text">'. __( 'Pause', 'cf7-telegram' ) . '</span>'. __( 'Pause', 'cf7-telegram' ) . '</a>
+				<a class="refuse" data-action="refuse" ><span class="screen-reader-text">'. __( 'Delete', 'cf7-telegram' ) . '</span>'. __( 'Delete', 'cf7-telegram' ) . '</a>
 			</div>
 		</div>';
 		
@@ -551,12 +557,12 @@ class wpcf7_Telegram{
 		foreach ( $this->addons as $slug => $name ) :
 			$attachment_addon_link = "https://nebster.net/product/contact-form-7-telegram-attachments/";
 			echo class_exists( $slug ) ?
-				'<p>' . __( 'Uses addon:', WPCF7TG_DOMAIN ) . ' ' . $name . '</p>' :
+				'<p>' . __( 'Uses addon:', 'cf7-telegram' ) . ' ' . $name . '</p>' :
 				/* translators: 1. File sending extension link, 2. end sale date, 3. "Get it now!" link  */
-				sprintf( __( 'We have a %1$s available that is 75%% OFF until %2$s: %3$s', WPCF7TG_DOMAIN ),
-					'<a href="'.$attachment_addon_link.'" target="_blank" >' . __( 'File sending extension', WPCF7TG_DOMAIN ) . '</a>',
+				sprintf( __( 'We have a %1$s available that is 75%% OFF until %2$s: %3$s', 'cf7-telegram' ),
+					'<a href="'.$attachment_addon_link.'" target="_blank" >' . __( 'File sending extension', 'cf7-telegram' ) . '</a>',
 					date_i18n( get_option( 'date_format' ), strtotime( '31-12-' . date( 'Y' ) )  ),
-					'<a href="'.$attachment_addon_link.'" target="_blank" >' . __( 'Get it now!', WPCF7TG_DOMAIN ) . '</a>',
+					'<a href="'.$attachment_addon_link.'" target="_blank" >' . __( 'Get it now!', 'cf7-telegram' ) . '</a>',
 				) . '</p>';
 		endforeach;
 	}

--- a/cf7-telegram/languages/cf7-telegram.pot
+++ b/cf7-telegram/languages/cf7-telegram.pot
@@ -1,115 +1,224 @@
-#, fuzzy
+# Copyright (C) 2024 Hokku
+# This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Contact Form 7 Telegram\n"
-"POT-Creation-Date: 2020-02-09 13:07+0300\n"
-"PO-Revision-Date: 2020-02-08 19:05+0300\n"
-"Last-Translator: \n"
-"Language-Team: iTRON <public@itron.pro>\n"
+"Project-Id-Version: Contact Form 7 + Telegram 1.0-rc1\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/cf7-telegram\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
-"X-Poedit-Basepath: ..\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: en_GB\n"
-"X-Poedit-KeywordsList: __;_e;sprintf\n"
-"X-Poedit-SearchPath-0: .\n"
+"POT-Creation-Date: 2024-02-08T02:27:47+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.8.1\n"
+"X-Domain: cf7-telegram\n"
 
-#: inc/class-wpcf7telegram.php:39
+#. Plugin Name of the plugin
+msgid "Contact Form 7 + Telegram"
+msgstr ""
+
+#. Description of the plugin
+msgid "Sends messages to Telegram-chat"
+msgstr ""
+
+#. Author of the plugin
+msgid "Hokku"
+msgstr ""
+
+#: classes/wpcf7telegram.php:40
 msgid "Prevent duplicate object creation"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:84
+#: classes/wpcf7telegram.php:45
+msgid "File Sending"
+msgstr ""
+
+#: classes/wpcf7telegram.php:91
+#: lib/Settings.php:60
 msgid "Do you really want to approve?"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:85
+#: classes/wpcf7telegram.php:92
+#: lib/Settings.php:61
 msgid "Do you really want to refuse?"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:86
+#: classes/wpcf7telegram.php:93
+#: lib/Settings.php:62
+msgid "Do you really want to pause?"
+msgstr ""
+
+#: classes/wpcf7telegram.php:94
+#: lib/Settings.php:63
 msgid "Successfully approved"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:87
+#: classes/wpcf7telegram.php:95
+#: lib/Settings.php:64
 msgid "Request refused"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:96
+#: classes/wpcf7telegram.php:104
 msgid "Bot-settings"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:103
+#: classes/wpcf7telegram.php:111
 msgid "Bot Token<br/><small>You need to create your own Telegram-Bot.<br/><a target=\"_blanc\" href=\"https://core.telegram.org/bots#3-how-do-i-create-a-bot\">How to create</a></small>"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:112
+#: classes/wpcf7telegram.php:120
 msgid "Defined by WPFC7TG_BOT_TOKEN constant"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:112
+#: classes/wpcf7telegram.php:120
 msgid "or define by WPFC7TG_BOT_TOKEN constant"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:140
+#: classes/wpcf7telegram.php:148
+#: lib/Settings.php:18
 msgid "Telegram notificator settings"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:150
+#: classes/wpcf7telegram.php:158
 msgid "Just use the shortcode <code>[telegram]</code> in the form for activate notification through Telegram."
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:286
-msgid "Error has occured. See php error log."
+#: classes/wpcf7telegram.php:302
+msgid "An error has occured. See php error log."
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:297
+#: classes/wpcf7telegram.php:313
 msgid "Bot username"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:301
+#: classes/wpcf7telegram.php:318
 msgid "Bot is online"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:302
+#: classes/wpcf7telegram.php:319
 msgid "Bot is broken"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:302
+#: classes/wpcf7telegram.php:319
 msgid "unknown"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:306
+#: classes/wpcf7telegram.php:326
 msgid "Subscribers list"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:311
+#: classes/wpcf7telegram.php:331
 msgid "List is empty"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:313
-#, php-format
+#. translators: "cf7tg_start" command
+#: classes/wpcf7telegram.php:333
 msgid "Add user: send the <code>%s</code> comand to your bot"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:314
-#, php-format
+#. translators: "cf7tg_start" command
+#: classes/wpcf7telegram.php:335
 msgid "Add group: add your bot to the group and send the <code>%s</code> comand to your group"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:408
+#: classes/wpcf7telegram.php:429
 msgid "Subscribed for Contact Form 7 notifications from"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:505
+#: classes/wpcf7telegram.php:526
 msgid "Approve"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:506
+#: classes/wpcf7telegram.php:527
+#: lib/Settings.php:52
 msgid "Pause"
 msgstr ""
 
-#: inc/class-wpcf7telegram.php:507
+#: classes/wpcf7telegram.php:528
 msgid "Delete"
+msgstr ""
+
+#: classes/wpcf7telegram.php:550
+msgid "Extensions"
+msgstr ""
+
+#: classes/wpcf7telegram.php:555
+msgid "Uses addon:"
+msgstr ""
+
+#. translators: 1. File sending extension link, 2. end sale date, 3. "Get it now!" link
+#: classes/wpcf7telegram.php:557
+msgid "We have a %1$s available that is 75%% OFF until %2$s: %3$s"
+msgstr ""
+
+#: classes/wpcf7telegram.php:558
+msgid "File sending extension"
+msgstr ""
+
+#: classes/wpcf7telegram.php:560
+msgid "Get it now!"
+msgstr ""
+
+#: lib/Settings.php:41
+msgid "New Channel Name"
+msgstr ""
+
+#: lib/Settings.php:42
+msgid "Create new channel"
+msgstr ""
+
+#: lib/Settings.php:43
+msgid "Rename channel"
+msgstr ""
+
+#: lib/Settings.php:44
+msgid "Connect form"
+msgstr ""
+
+#: lib/Settings.php:45
+msgid "Connect bot"
+msgstr ""
+
+#. translators: channel name
+#: lib/Settings.php:47
+msgid "Disconnect this bot from %s channel?"
+msgstr ""
+
+#. translators: channel name
+#: lib/Settings.php:49
+msgid "Do you really want to remove %s channel?"
+msgstr ""
+
+#. translators: 1. form name, 2. channel name
+#: lib/Settings.php:51
+msgid "Do you really want to disconnect %1$s form from %2$s channel?"
+msgstr ""
+
+#: lib/Settings.php:53
+msgid "Resume"
+msgstr ""
+
+#: lib/Settings.php:56
+msgid "Bot"
+msgstr ""
+
+#: lib/Settings.php:57
+msgid "API Key"
+msgstr ""
+
+#: lib/Settings.php:65
+msgid "Muted"
+msgstr ""
+
+#: lib/Settings.php:66
+msgid "Mute"
+msgstr ""
+
+#: lib/Settings.php:67
+msgid "Remove"
+msgstr ""
+
+#: lib/Settings.php:68
+msgid "Activate"
 msgstr ""

--- a/cf7-telegram/lib/Settings.php
+++ b/cf7-telegram/lib/Settings.php
@@ -15,7 +15,7 @@ class Settings {
 		?>
 		<div id="cf7-telegram-container">
 			<div class="wrap">
-				<h1><?php echo __( 'Telegram notificator settings', WPCF7TG_DOMAIN ); ?></h1>
+				<h1><?php echo __( 'Telegram notificator settings', 'cf7-telegram' ); ?></h1>
 			</div>
 		</div>
 		<?php
@@ -38,31 +38,34 @@ class Settings {
 			'nonce'		        => wp_create_nonce( 'wpcf7_telegram_nonce' ),
 			'l10n'		        => [
 				'channel' => [
-					'new_channel_name'  	    => __( 'New Channel Name', WPCF7TG_DOMAIN ),
-					'create_new_channel'	    => __( 'Create new channel', WPCF7TG_DOMAIN ),
-					'rename_channel'		    => __( 'Rename channel', WPCF7TG_DOMAIN ),
-					'connect_form'              => __( 'Connect form', WPCF7TG_DOMAIN ),
-					'connect_bot'               => __( 'Connect bot', WPCF7TG_DOMAIN ),
-					'confirm_disconnect_bot'    => __( 'Disconnect this bot from %s channel?', WPCF7TG_DOMAIN ),
-					'confirm_remove_channel'    => __( 'Do you really want to remove %s channel?', WPCF7TG_DOMAIN ),
-					'confirm_disconnect_form'   => __( 'Do you really want to disconnect %s form from %s channel?', WPCF7TG_DOMAIN ),
-					'pause_chat'                => __( 'Pause', WPCF7TG_DOMAIN ),
-					'resume_chat'               => __( 'Resume', WPCF7TG_DOMAIN ),
+					'new_channel_name'  	    => __( 'New Channel Name', 'cf7-telegram' ),
+					'create_new_channel'	    => __( 'Create new channel', 'cf7-telegram' ),
+					'rename_channel'		    => __( 'Rename channel', 'cf7-telegram' ),
+					'connect_form'              => __( 'Connect form', 'cf7-telegram' ),
+					'connect_bot'               => __( 'Connect bot', 'cf7-telegram' ),
+					/* translators: channel name */
+					'confirm_disconnect_bot'    => __( 'Disconnect this bot from %s channel?', 'cf7-telegram' ),
+					/* translators: channel name */
+					'confirm_remove_channel'    => __( 'Do you really want to remove %s channel?', 'cf7-telegram' ),
+					/* translators: 1. form name, 2. channel name */
+					'confirm_disconnect_form'   => __( 'Do you really want to disconnect %1$s form from %2$s channel?', 'cf7-telegram' ),
+					'pause_chat'                => __( 'Pause', 'cf7-telegram' ),
+					'resume_chat'               => __( 'Resume', 'cf7-telegram' ),
 				],
 				'bot'   => [
-					'bot'       =>  __( 'Bot', WPCF7TG_DOMAIN ),
-					'api_key'   =>  __( 'API Key', WPCF7TG_DOMAIN ),
+					'bot'       =>  __( 'Bot', 'cf7-telegram' ),
+					'api_key'   =>  __( 'API Key', 'cf7-telegram' ),
 				],
 				'chat'  => [
-					'confirm_approve'	=> __( 'Do you really want to approve?', WPCF7TG_DOMAIN ),
-					'confirm_refuse'	=> __( 'Do you really want to refuse?', WPCF7TG_DOMAIN ),
-					'confirm_pause'     => __( 'Do you really want to pause?', WPCF7TG_DOMAIN ),
-					'approved'          => __( 'Successfully approved', WPCF7TG_DOMAIN ),
-					'refused'           => __( 'Request refused', WPCF7TG_DOMAIN ),
-					'chat_is_muted'     => __( 'Muted', WPCF7TG_DOMAIN ),
-					'mute_chat'         => __( 'Mute', WPCF7TG_DOMAIN ),
-					'remove_chat'       => __( 'Remove', WPCF7TG_DOMAIN ),
-					'activate_chat'     => __( 'Activate', WPCF7TG_DOMAIN ),
+					'confirm_approve'	=> __( 'Do you really want to approve?', 'cf7-telegram' ),
+					'confirm_refuse'	=> __( 'Do you really want to refuse?', 'cf7-telegram' ),
+					'confirm_pause'     => __( 'Do you really want to pause?', 'cf7-telegram' ),
+					'approved'          => __( 'Successfully approved', 'cf7-telegram' ),
+					'refused'           => __( 'Request refused', 'cf7-telegram' ),
+					'chat_is_muted'     => __( 'Muted', 'cf7-telegram' ),
+					'mute_chat'         => __( 'Mute', 'cf7-telegram' ),
+					'remove_chat'       => __( 'Remove', 'cf7-telegram' ),
+					'activate_chat'     => __( 'Activate', 'cf7-telegram' ),
 				],
 			],
 		) );


### PR DESCRIPTION
This PR apply the following changes:

- Updates text domain from `WPCF7TG_DOMAIN` to `'cf7-telegram'` to comply with the standards ([see](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#:~:text=The%20text%20domain%20must,of%20the%20plugin))
- Improve the text domain loading ([see](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain))
- Adds translators comments to string with placeholders ([see](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#descriptions))
- Update the translation template with missing strings and new metadata.
- Renames the translation template to comply with the standards.

Closes: #18