### PR TITLE
hotfix: Unexpected 404 Error | Telegram Token is not sanitized and trimmed

### DIFF
--- a/plugin-dir/classes/wpcf7telegram.php
+++ b/plugin-dir/classes/wpcf7telegram.php
@@ -212,7 +212,7 @@ class wpcf7_Telegram{
 			return;
 		endif;
 		
-		$token = $_REQUEST['wpcf7_telegram_tkn'];
+		$token = trim( sanitize_text_field( $_REQUEST['wpcf7_telegram_tkn'] ) );
 		$this->set_bot_token( $token );
 		return $this;
 	}


### PR DESCRIPTION
Hey guys, I just noticed when you copy `Telegram Token` from `Bot Father` it has a lot of **spaces** at start and end.

<img width="197" height="345" alt="image" src="https://github.com/user-attachments/assets/e36e10cf-4b80-4734-a267-206b62e556dd" />

Look, this is what I get after clicking "Copy" button (token was hidden on purpose).
```

          **********:AAE**********************
        
```

I checked logs and got this error:

<img width="398" height="42" alt="image" src="https://github.com/user-attachments/assets/975d2e35-0753-4fde-bf1a-c45d542143ae" />

I'd recommend you to improve debug logging and sanitize + trim telegram token.