### PR TITLE
feat: Make it possible to format message output before formatting

### DIFF
--- a/plugin-dir/classes/wpcf7telegram.php
+++ b/plugin-dir/classes/wpcf7telegram.php
@@ -279,13 +279,23 @@ class wpcf7_Telegram{
 		if ( false === @ $mail['use_html'] ) :
 			$mode = 'Markdown';
 			$output = $me->markdown( $output ); 			
-			$output = wp_kses( $output, array() );
+			$formatted_output = wp_kses( $output, array() );
 		else :
-			$output = wp_kses( $output, array(
+			$formatted_output = wp_kses( $output, array(
 				'a'	=> array( 'href' => true ),
 				'b' => array(), 'strong' => array(), 'i' => array(), 'em' => array(), 'u' => array(), 'ins' => array(), 's' => array(), 'strike' => array(), 'del' => array(), 'code' => array(), 'pre' => array(),
 			) );
-		endif;		
+		endif;
+
+		/**
+		 * Filters the output of the message before it is sent to Telegram.
+		 *
+		 * @param string $formatted_output The formatted output of the message.
+		 * @param string $output The original output of the message.
+		 * @param string $mode The mode of the message (HTML or Markdown).
+		 * @return string The filtered output of the message.
+		 */
+		$output = apply_filters( 'wpcf7tg_sendMessage_output', $formatted_output, $output, $mode );
 		
 		foreach( $list as $id => $chat ) :
 			$chat_id = is_numeric( $id ) ? $id : $chat['id'];

--- a/plugin-dir/lib/Controllers/CF7.php
+++ b/plugin-dir/lib/Controllers/CF7.php
@@ -59,13 +59,23 @@ class CF7 {
 		if ( false === @$mail['use_html'] ) :
 			$mode = 'Markdown';
 			$output = self::markdown( $output );
-			$output = wp_kses( $output, [] );
+			$formatted_output = wp_kses( $output, [] );
 		else :
-			$output = wp_kses( $output, array(
+			$formatted_output = wp_kses( $output, array(
 				'a'	=> array( 'href' => true ),
 				'b' => [], 'strong' => [], 'i' => [], 'em' => [], 'u' => [], 'ins' => [], 's' => [], 'strike' => [], 'del' => [], 'code' => [], 'pre' => [],
 			) );
 		endif;
+
+		/**
+		 * Filters the output of the message before it is sent to Telegram.
+		 *
+		 * @param string $formatted_output The formatted output of the message.
+		 * @param string $output The original output of the message.
+		 * @param string $mode The mode of the message (HTML or Markdown).
+		 * @return string The filtered output of the message.
+		 */
+		$output = apply_filters( 'wpcf7tg_sendMessage_output', $formatted_output, $output, $mode );
 
 		$targetChannels = $client->getChannels()->filterByIDs( $connections->column( 'to' ) );
 		foreach ( $targetChannels as $channel ) {


### PR DESCRIPTION
Hey guys, I need this to properly format my message in my custom theme as I use `<table>` to output user's filled fields.

I will use this code in my theme to format message. Here is example.
```
/**
 * Custom Telegram message formatting for Contact Form 7
 * Parses table structures and formats them properly
 */
function cf7_telegram_message_formatting( $formatted_output, $original_output, $mode ) {
	// Only format tables in HTML mode
	if ( 'HTML' === $mode && strpos( $original_output, '<table' ) !== false ) {
		return cf7_telegram_parse_table_structure( $original_output );
	}

	// Return original output for non-table or non-HTML mode
	return $formatted_output;
}
add_filter( 'wpcf7tg_sendMessage_output', 'cf7_telegram_message_formatting', 10, 3 );

/**
 * Parse table structure from HTML
 *
 * @param string $html HTML content
 * @return string Formatted message
 */
function cf7_telegram_parse_table_structure( $html ) {
	// Create a DOMDocument to parse the HTML
	$dom = new DOMDocument();

	// Suppress warnings for malformed HTML
	libxml_use_internal_errors( true );
	$dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
	libxml_clear_errors();

	$tables = $dom->getElementsByTagName( 'table' );

	if ( 0 === $tables->length ) {
		return $html;
	}

	$formatted_message = '';

	foreach ( $tables as $table ) {
		$table_data = cf7_telegram_extract_table_data( $table );

		if ( ! empty( $table_data['title'] ) ) {
			$formatted_message .= '<strong>' . $table_data['title'] . '</strong>' . "\n\n";
		}

		if ( ! empty( $table_data['fields'] ) ) {
			foreach ( $table_data['fields'] as $field ) {
				if ( ! empty( $field['label'] ) && ! empty( $field['value'] ) ) {
					$formatted_message .= '<strong>' . $field['label'] . '</strong>' . "\n";
					$formatted_message .= '<code>' . $field['value'] . '</code>' . "\n\n";
				} elseif ( ! empty( $field['label'] ) ) {
					$formatted_message .= '<strong>' . $field['label'] . '</strong>' . "\n\n";
				}
			}
		}
	}

	// Clean up the message
	$formatted_message = trim( $formatted_message );

	return $formatted_message;
}

/**
 * Extract table data from DOMElement
 *
 * @param DOMElement $table Table element
 * @return array Table data
 */
function cf7_telegram_extract_table_data( $table ) {
	$data = array(
		'title'  => '',
		'fields' => array(),
	);

	// Look for title in thead or first row with colspan
	$rows = $table->getElementsByTagName( 'tr' );

	foreach ( $rows as $row ) {
		$cells = $row->getElementsByTagName( 'td' );

		// Check if this is a title row (has colspan or is in thead)
		if ( 1 === $cells->length ||
			( $cells->length > 0 && $cells->item( 0 )->hasAttribute( 'colspan' ) ) ) {

			$title_text = trim( wp_strip_all_tags( $cells->item( 0 )->textContent ) );
			if ( ! empty( $title_text ) && empty( $data['title'] ) ) {
				$data['title'] = $title_text;
			}
			continue;
		}

		// Extract field data (label and value)
		if ( $cells->length >= 2 ) {
			$label = trim( wp_strip_all_tags( $cells->item( 0 )->textContent ) );
			$value = trim( wp_strip_all_tags( $cells->item( 1 )->textContent ) );

			// Skip empty rows or rows with empty labels
			if ( ! empty( $label ) ) {
				$data['fields'][] = array(
					'label' => $label,
					'value' => $value,
				);
			}
		}
	}

	return $data;
}
```