### PR TITLE
Fix truncated bot name copy

### DIFF
--- a/plugin-dir/react/src/components/BotView.js
+++ b/plugin-dir/react/src/components/BotView.js
@@ -1,6 +1,6 @@
 /* global wp */
 
-import React, {useEffect, useRef} from 'react';
+import React from 'react';
 import {copyWithTooltip} from '../utils/main';
 import {getChatStatus, getToggleButtonLabel} from '../utils/chatStatus';
 
@@ -27,6 +27,7 @@ const BotView = ({
 
     let status = online === true ? 'online' : online === false ? 'offline' : 'unknown';
     let truncatedName = nameValue.slice(0, 18);
+    const fullBotName = `@${nameValue}`;
 
     isEditingToken && renderEditTokenCount.current < 1 && setTokenValue('');
     isEditingToken && renderEditTokenCount.current++;
@@ -41,7 +42,7 @@ const BotView = ({
                     <div className="bot-title">
                         <div
                             className={`bot-name ${status} copyable`}
-                            onClick={(e) => copyWithTooltip(e.target)}
+                            onClick={(e) => copyWithTooltip(e.currentTarget, fullBotName)}
                             title={wp.i18n.__( 'Click to copy bot name', 'cf7-telegram' )}
                         >
                             @{truncatedName}{truncatedName !== nameValue && '...'}
@@ -49,7 +50,7 @@ const BotView = ({
 
                         <div
                             className={`bot-command copyable`}
-                            onClick={(e) => copyWithTooltip(e.target)}
+                            onClick={(e) => copyWithTooltip(e.currentTarget)}
                             title={wp.i18n.__( 'Click to copy bot command', 'cf7-telegram' )}
                             >
                             /cf7tg_start
@@ -71,7 +72,7 @@ const BotView = ({
                             <div
                                 className="php-const-hint copyable"
                                 title={wp.i18n.__( 'Click to copy PHP code', 'cf7-telegram' )}
-                                onClick={(e) => copyWithTooltip(e.target, `const ${bot.phpConst} = 'your_token';`)}
+                                onClick={(e) => copyWithTooltip(e.currentTarget, `const ${bot.phpConst} = 'your_token';`)}
                             >
                                 {wp.i18n.__( 'set by PHP const', 'cf7-telegram' )}
                             </div>

--- a/plugin-dir/react/src/components/BotView.test.js
+++ b/plugin-dir/react/src/components/BotView.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import BotView from './BotView';
+
+describe('BotView copyable bot name', () => {
+    const originalClipboard = navigator.clipboard;
+    const originalSecureContext = window.isSecureContext;
+
+    beforeEach(() => {
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: {
+                writeText: jest.fn().mockResolvedValue(undefined),
+            },
+        });
+
+        Object.defineProperty(window, 'isSecureContext', {
+            configurable: true,
+            value: true,
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: originalClipboard,
+        });
+
+        Object.defineProperty(window, 'isSecureContext', {
+            configurable: true,
+            value: originalSecureContext,
+        });
+    });
+
+    it('copies the full bot name when the visible name is truncated', async () => {
+        const longName = 'super_long_telegram_bot_name';
+        const truncatedName = longName.slice(0, 18);
+
+        render(
+            <BotView
+                bot={{id: 1, isTokenDefinedByConst: false, phpConst: 'CF7TG_TOKEN'}}
+                chatsForBot={[]}
+                bot2ChatConnections={[]}
+                updatingStatusIds={[]}
+                isEditingToken={false}
+                nameValue={longName}
+                isTokenEmpty={false}
+                tokenValue="1234567890"
+                saving={false}
+                error=""
+                handleEditToken={jest.fn()}
+                deleteBot={jest.fn()}
+                handleKeyDown={jest.fn()}
+                setTokenValue={jest.fn()}
+                handleToggleChatStatus={jest.fn()}
+                handleDisconnectChat={jest.fn()}
+                online={true}
+                renderEditTokenCount={{current: 0}}
+            />
+        );
+
+        const botName = screen.getByTitle('Click to copy bot name');
+
+        expect(botName).toHaveTextContent(`@${truncatedName}...`);
+
+        fireEvent.click(botName);
+
+        await waitFor(() => {
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`@${longName}`);
+        });
+    });
+});


### PR DESCRIPTION
Pass the full bot handle to the clipboard action so long names still copy correctly when the UI shows an ellipsis.

Add a React test that covers copying a truncated bot name.